### PR TITLE
Feat/desktop layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,6 +79,10 @@ p, li, figcaption {
 .preview-card-content {
   background-color: var(--white);
   padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
 }
 
 .preview-card-content .category {
@@ -158,7 +162,7 @@ p, li, figcaption {
 @media only screen and (min-width: 768px) {
   .preview-card {
     display: flex;
-    max-width: 70%;
+    max-width: 620px;
   }
 
   .preview-card-image {
@@ -167,6 +171,7 @@ p, li, figcaption {
   
   .preview-card-content {
     max-width: 50%;
+    padding: 3rem;
   }
 
   .preview-card,
@@ -177,6 +182,10 @@ p, li, figcaption {
   .preview-card,
   .preview-card-content {
     border-radius: 0 1rem 1rem 0;
+  }
+
+  .preview-card .price-container {
+    margin: 1rem 0;
   }
 
 }

--- a/css/style.css
+++ b/css/style.css
@@ -71,11 +71,6 @@ p, li, figcaption {
   border-radius: 1rem 1rem 0 0 ;
 }
 
-/*
-  TO-DO: Issue # 4 change layout of card for desktop, including image
-*/
-
-
 .preview-card,
 .preview-card-content {
   border-radius: 0 0 1rem 1rem;
@@ -158,4 +153,30 @@ p, li, figcaption {
   transition: all 0.2s ease-in-out;
   cursor: pointer;
   color: var(--white);
+}
+
+@media only screen and (min-width: 768px) {
+  .preview-card {
+    display: flex;
+    max-width: 70%;
+  }
+
+  .preview-card-image {
+    height: 100%;
+  }
+  
+  .preview-card-content {
+    max-width: 50%;
+  }
+
+  .preview-card,
+  .preview-card-image {
+    border-radius: 1rem 0 0 1rem ;
+  }
+
+  .preview-card,
+  .preview-card-content {
+    border-radius: 0 1rem 1rem 0;
+  }
+
 }


### PR DESCRIPTION
Closes #4 

Added the layout and style for .preview-card on desktop. Defined desktop styles on breakpoint min-width: 768px, avoiding a separate layout for tablet. 