### PR TITLE
fix: adapt current layout to origina design

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -162,7 +162,7 @@ p, li, figcaption {
 @media only screen and (min-width: 768px) {
   .preview-card {
     display: flex;
-    max-width: 620px;
+    max-width: 600px;
   }
 
   .preview-card-image {
@@ -171,7 +171,7 @@ p, li, figcaption {
   
   .preview-card-content {
     max-width: 50%;
-    padding: 3rem;
+    padding: 2.5rem;
   }
 
   .preview-card,


### PR DESCRIPTION
Closes #20 

Adjusted the max-width of .preview-card in mobile from 620px to 600px, leaving a height of 450px on tablet and desktop